### PR TITLE
Adds staging deploys that rely on linting to pass

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -1,5 +1,7 @@
 name: Deploy plugin to Production
 
+concurrency: production
+
 on:
     workflow_dispatch:
     workflow_run:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,5 +1,7 @@
 name: Deploy plugin to Staging
 
+concurrency: staging
+
 on:
     push:
         branches:
@@ -7,10 +9,7 @@ on:
 
 jobs:
     Linting:
-        uses: ./.github/workflows/linting.yml
-        concurrency:
-            group: staging-deploy
-            cancel-in-progress: true
+
 
     Deploy:
         name: FTP-Deploy-Action
@@ -20,7 +19,11 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 2
+            - name: Linting
+              id: linting
+              uses: ./.github/workflows/linting.yml
             - name: FTP-Deploy-Action
+              if: steps.linting.outcome == 'success'
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:
                   ftp-server: sftp://sftp.wp.com/htdocs/wp-content/plugins/custom-plugin/

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,26 +1,23 @@
 name: Deploy plugin to Staging
 
-concurrency: staging
-
 on:
     push:
         branches:
             - staging
 
 jobs:
+    Linting:
+        uses: ./.github/workflows/linting.yml
+
     Deploy:
         name: FTP-Deploy-Action
         runs-on: ubuntu-latest
-
+        needs: Linting
         steps:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 2
-            - name: Linting
-              id: linting
-              uses: ./.github/workflows/linting.yml
             - name: FTP-Deploy-Action
-              if: steps.linting.outcome == 'success'
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:
                   ftp-server: sftp://sftp.wp.com/htdocs/wp-content/plugins/custom-plugin/

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -8,9 +8,6 @@ on:
             - staging
 
 jobs:
-    Linting:
-
-
     Deploy:
         name: FTP-Deploy-Action
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -8,6 +8,9 @@ on:
 jobs:
     Linting:
         uses: ./.github/workflows/linting.yml
+        concurrency:
+            group: staging-deploy
+            cancel-in-progress: true
 
     Deploy:
         name: FTP-Deploy-Action

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,5 +1,7 @@
 name: Deploy plugin to Staging
 
+concurrency: staging
+
 on:
     push:
         branches:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,7 @@
 name: Static Linting
 
 on:
+    workflow_call:
     pull_request:
     push:
         branches:

--- a/plugin.php
+++ b/plugin.php
@@ -19,22 +19,3 @@ namespace PublisherName;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
-
-/**
- * Initialize plugin functionality on WordPress init.
- * Adds custom content to the site header.
- *
- * @return void
- */
-
-// Add action to wp_head to insert content in header.
-add_action(
-	'wp_head',
-	function() {
-		// Output custom meta tags or other header content.
-		if($name ==== 'test') {
-
-		echo 'JUST A TEST';
-		]
-	}
-);

--- a/plugin.php
+++ b/plugin.php
@@ -32,6 +32,9 @@ add_action(
 	'wp_head',
 	function() {
 		// Output custom meta tags or other header content.
+		if($name ==== 'test') {
+
 		echo 'JUST A TEST';
+		]
 	}
 );

--- a/plugin.php
+++ b/plugin.php
@@ -19,3 +19,19 @@ namespace PublisherName;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Initialize plugin functionality on WordPress init.
+ * Adds custom content to the site header.
+ *
+ * @return void
+ */
+
+// Add action to wp_head to insert content in header.
+add_action(
+	'wp_head',
+	function() {
+		// Output custom meta tags or other header content.
+		echo 'JUST A TEST';
+	}
+);


### PR DESCRIPTION
This PR adds a staging-deploy action that is only run on pushes to the staging branch. It requires that the Linting job passes before running the actual deploy.

Closes #2 