### PR TITLE
PHPCS rule changes to account for VIP functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"phpcompatibility/phpcompatibility-wp": "*"
 	},
 	"scripts": {
-		"lint": "./vendor/bin/phpcs --standard=phpcs.xml"
+		"lint": "./vendor/bin/phpcs --standard=phpcs.xml -n"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,15 +4,8 @@
 
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-Docs" />
-	<rule ref="WordPress-VIP-Go">
-		<exclude name="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown" />
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts" />
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid" />
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid" />
-	</rule>
-
+	<rule ref="WordPress-VIP-Go"/>
 	<!-- Override some rules from WordPressVIPMinimum that call for VIP functions not available on the Newspack platform. -->
-	<!--
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts">
 		<type>warning</type>
 		<message>%s is uncached, please use it with caution.</message>
@@ -23,10 +16,16 @@
 	</rule>
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid">
 		<type>warning</type>
-		<message>%s() is uncached, please use it with caution.</message>
+			<message>%s() is uncached, please use it with caution.</message>
 	</rule>
-	-->
+	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsRemoteFile">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<!-- end of overrides -->
 
+
+	<!-- Standard WordPress sniffs -->
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
@@ -40,6 +39,8 @@
 		<!-- Allow for PSR-4 file names-->
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<!-- Format inline comments how ever you want -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,6 +37,26 @@
 		<type>warning</type>
 		<message>%s is uncached, please use it with caution.</message>
 	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.get_adjacent_post_get_next_post_link">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.get_adjacent_post_get_next_post">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.get_adjacent_post_get_previous_post_link">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.get_adjacent_post_get_previous_post">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.get_adjacent_post_get_adjacent_post">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
 	<!-- end of overrides -->
 
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,10 @@
 
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-Docs" />
-	<rule ref="WordPress-VIP-Go"/>
+	<rule ref="WordPress-VIP-Go" >
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
+	</rule>
+
 	<!-- Override some rules from WordPressVIPMinimum that call for VIP functions not available on the Newspack platform. -->
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts">
 		<type>warning</type>
@@ -19,6 +22,18 @@
 			<message>%s() is uncached, please use it with caution.</message>
 	</rule>
 	<rule ref="WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsRemoteFile">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Performance.OrderByRand.orderby_orderby">
+		<type>warning</type>
+		<message>The %s parameter can be slow, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role">
+		<type>warning</type>
+		<message>%s is uncached, please use it with caution.</message>
+	</rule>
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_old_slug_redirect_wp_old_slug_redirect">
 		<type>warning</type>
 		<message>%s is uncached, please use it with caution.</message>
 	</rule>


### PR DESCRIPTION
This PR is meant to address some VIP PHPCS sniffs that recommend functions not available on the Newspack platform.

The approach taken is to change the messaging to inform the user that the code in question should be used with caution and it may be slow or uncached and to reduce the sniff to a warning so that it appears in the IDE.

I have also updated the linting command to bypass warnings so only actual errors will be triggered when the `lint` command is run either manually, by Husky or via an Action.

There are a [number of other sniffs from the VIP ruleset ](https://github.com/Automattic/VIP-Coding-Standards/blob/develop/WordPressVIPMinimum/Sniffs/Functions/RestrictedFunctionsSniff.php)that will fire errors that I left alone as I think they are probably good to follow.

Closes: #9 


## Testing Instructions


```php
// Should fire warnings
$query_args = array(
	'post_type'      => 'post',
	'posts_per_page' => 10,
	'orderby'         => 'rand',
);
$new_query = new \WP_Query( $query_args );

get_adjacent_post(true, '', true );
get_previous_post(true );
get_previous_post_link('%link', '%title', true );
get_next_post( true );
get_next_post_link('%link', '%title', true );
role_add_role( 'test_role', 'Test Role', array( 'read' => true ) );
wp_old_slug_redirect( 'test-slug' );
file_get_contents( 'https://www.google.com' );
count_user_posts( 1, 'post' );
attachment_url_to_postid( 'https://www.google.com' );
url_to_postid( 'https://www.google.com' );

// Should not fire errors
wp_remote_get( 'https://www.google.com' );
```

1. Add the snippet above to the plugin.php
2. Confirm that warnings are showing in the IDE
3. Confirm that none of the messages mention using VIP functions
4. Confirm that `wp_remote_get` fires no errors or warning
5. Run `npm run lint` and confirm that none of the warnings are flagged