### PR TITLE
Generate and upload `vendor` and `build` directories via actions. 

### DIFF
--- a/.git-ftp-include
+++ b/.git-ftp-include
@@ -1,0 +1,2 @@
+!build/
+!vendor/

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -18,6 +18,26 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 2
+
+            - name: Use Node.js 18
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '18'
+
+            - name: Build Project
+              run: |
+                  npm install
+                  npm run build --if-present
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  tools: composer:v2
+
+            - name: Install Composer dependencies
+              run: composer install --no-dev --optimize-autoloader
+
             - name: FTP-Deploy-Action
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -20,6 +20,26 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 2
+
+            - name: Use Node.js 18
+              uses: actions/setup-node@v2
+              with:
+                 node-version: '18'
+
+            - name: Build Project
+              run: |
+                npm install
+                npm run build --if-present
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  tools: composer:v2
+
+            - name: Install Composer dependencies
+              run: composer install --no-dev --optimize-autoloader
+
             - name: FTP-Deploy-Action
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,14 @@
 		"phpcompatibility/phpcompatibility-wp": "*"
 	},
 	"scripts": {
+		"build": [
+			"composer update --no-dev",
+			"composer dump-autoload -o --no-dev"
+		],
+		"dev": [
+			"composer update",
+			"composer dump-autoload"
+		],
 		"lint": "./vendor/bin/phpcs --standard=phpcs.xml -n"
 	},
 	"autoload": {


### PR DESCRIPTION
@leogermani had the great idea of using actions to generate composer and JS builds rather than having them in version controls.

This PR  introduces those changes.