### PR TITLE
avoid errors on deploy

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -26,7 +26,7 @@ jobs:
 
             - name: Build Project
               run: |
-                  npm install
+                  npm ci
                   npm run build --if-present
 
             - name: Setup PHP

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: Build Project
               run: |
-                npm install
+                npm ci
                 npm run build --if-present
 
             - name: Setup PHP


### PR DESCRIPTION
If `npm install` is used in the deploy script, it will change the `package.json` file and make the whole action fail with an "fatal: Dirty repository: Having uncommitted changes. Exiting..."

Using `npm ci` instead fixes it. 