### PR TITLE
Update deployment workflows to use site names

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -16,94 +16,16 @@ jobs:
     Linting:
         uses: ./.github/workflows/linting.yml
 
-    generate-matrix:
-        runs-on: ubuntu-latest
-        outputs:
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-        steps:
-            - name: Generate deployment matrix from secrets
-              id: set-matrix
-              run: |
-                  # Fetch all repository secrets
-                  echo "Fetching secrets from GitHub API..."
-                  secrets_response=$(curl -s -H "Authorization: token ${{ secrets.DEPLOY_ACTION_TOKEN }}" \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    "https://api.github.com/repos/${{ github.repository }}/actions/secrets?per_page=100")
-
-                  # Debug: Show raw response
-                  echo "API Response:"
-                  echo "$secrets_response"
-
-                  # Check if response contains error
-                  if echo "$secrets_response" | jq -e '.message' > /dev/null 2>&1; then
-                    echo "API Error: $(echo "$secrets_response" | jq -r '.message')"
-                    exit 1
-                  fi
-
-                  # Check if secrets field exists and is not null
-                  if ! echo "$secrets_response" | jq -e '.secrets' > /dev/null 2>&1; then
-                    echo "No secrets field found in API response"
-                    exit 1
-                  fi
-
-                  # Extract PROD_SFTP_USER secrets
-                  echo "Looking for PROD_SFTP_USER secrets..."
-                  prod_secrets=$(echo "$secrets_response" | jq -r '.secrets[]? | select(.name | startswith("PROD_SFTP_USER")) | .name' 2>/dev/null || echo "")
-
-                  if [ -z "$prod_secrets" ]; then
-                    echo "No PROD_SFTP_USER secrets found"
-                    echo "Available secrets:"
-                    echo "$secrets_response" | jq -r '.secrets[]?.name // empty' 2>/dev/null || echo "Could not parse secrets"
-                    exit 1
-                  fi
-
-                  echo "Found PROD_SFTP_USER secrets:"
-                  echo "$prod_secrets"
-
-                  # Build matrix JSON
-                  matrix_items=()
-                  while IFS= read -r secret_name; do
-                    if [ -n "$secret_name" ]; then
-                      suffix=$(echo "$secret_name" | sed 's/PROD_SFTP_USER//')
-                      password_secret="PROD_SFTP_PASSWORD$suffix"
-
-                      echo "Processing: $secret_name -> $password_secret"
-
-                      matrix_item=$(jq -n \
-                        --arg name "$secret_name" \
-                        --arg suffix "$suffix" \
-                        --arg user_secret "$secret_name" \
-                        --arg password_secret "$password_secret" \
-                        '{
-                          name: $name,
-                          suffix: $suffix,
-                          user_secret: $user_secret,
-                          password_secret: $password_secret
-                        }')
-                      matrix_items+=("$matrix_item")
-                    fi
-                  done <<< "$prod_secrets"
-
-                  # Create final matrix
-                  if [ ${#matrix_items[@]} -eq 0 ]; then
-                    echo "No valid prod secrets found"
-                    exit 1
-                  fi
-
-                  # Join matrix items and create final JSON
-                  matrix_json=$(printf '%s\n' "${matrix_items[@]}" | jq -s '{"include": .}')
-
-                  # Output as a single line for GitHub Actions
-                  echo "matrix=$(echo "$matrix_json" | jq -c .)" >> $GITHUB_OUTPUT
-                  echo "Generated matrix:"
-                  echo "$matrix_json" | jq '.'
-
     Deploy:
         name: FTP-Deploy-Action
         runs-on: ubuntu-latest
-        needs: [Linting, generate-matrix]
+        needs: [Linting]
+        if: ${{ vars.PROD_SITES != '' }}
         strategy:
-            matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+            matrix:
+                # Site names are defined in repository variable PROD_SITES
+                # Example: PROD_SITES = ["SITE_1","SITE_2","SITE_3"]
+                site_name: ${{ fromJSON(vars.PROD_SITES) }}
             fail-fast: false
 
         steps:
@@ -112,7 +34,7 @@ jobs:
                   fetch-depth: 2
 
             - name: Use Node.js 18
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: '18'
 
@@ -130,10 +52,10 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --no-dev --optimize-autoloader
 
-            - name: FTP-Deploy-Action to prod${{ matrix.suffix }}
+            - name: FTP-Deploy-Action to Production Site ${{ matrix.site_name }}
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:
                   ftp-server: sftp://sftp.wp.com/htdocs/wp-content/plugins/custom-plugin/
-                  ftp-username: ${{ secrets[matrix.user_secret] }}
-                  ftp-password: ${{ secrets[matrix.password_secret] }}
+                  ftp-username: ${{ secrets[format('PROD_SFTP_USER_{0}', matrix.site_name)] }}
+                  ftp-password: ${{ secrets[format('PROD_SFTP_PASSWORD_{0}', matrix.site_name)] }}
                   git-ftp-args: --insecure

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -16,94 +16,16 @@ jobs:
     Linting:
         uses: ./.github/workflows/linting.yml
 
-    generate-matrix:
-        runs-on: ubuntu-latest
-        outputs:
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-        steps:
-            - name: Generate deployment matrix from secrets
-              id: set-matrix
-              run: |
-                  # Fetch all repository secrets
-                  echo "Fetching secrets from GitHub API..."
-                  secrets_response=$(curl -s -H "Authorization: token ${{ secrets.DEPLOY_ACTION_TOKEN }}" \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    "https://api.github.com/repos/${{ github.repository }}/actions/secrets?per_page=100")
-
-                  # Debug: Show raw response
-                  echo "API Response:"
-                  echo "$secrets_response"
-
-                  # Check if response contains error
-                  if echo "$secrets_response" | jq -e '.message' > /dev/null 2>&1; then
-                    echo "API Error: $(echo "$secrets_response" | jq -r '.message')"
-                    exit 1
-                  fi
-
-                  # Check if secrets field exists and is not null
-                  if ! echo "$secrets_response" | jq -e '.secrets' > /dev/null 2>&1; then
-                    echo "No secrets field found in API response"
-                    exit 1
-                  fi
-
-                  # Extract STAGING_SFTP_USER secrets
-                  echo "Looking for STAGING_SFTP_USER secrets..."
-                  staging_secrets=$(echo "$secrets_response" | jq -r '.secrets[]? | select(.name | startswith("STAGING_SFTP_USER")) | .name' 2>/dev/null || echo "")
-
-                  if [ -z "$staging_secrets" ]; then
-                    echo "No STAGING_SFTP_USER secrets found"
-                    echo "Available secrets:"
-                    echo "$secrets_response" | jq -r '.secrets[]?.name // empty' 2>/dev/null || echo "Could not parse secrets"
-                    exit 1
-                  fi
-
-                  echo "Found STAGING_SFTP_USER secrets:"
-                  echo "$staging_secrets"
-
-                  # Build matrix JSON
-                  matrix_items=()
-                  while IFS= read -r secret_name; do
-                    if [ -n "$secret_name" ]; then
-                      suffix=$(echo "$secret_name" | sed 's/STAGING_SFTP_USER//')
-                      password_secret="STAGING_SFTP_PASSWORD$suffix"
-
-                      echo "Processing: $secret_name -> $password_secret"
-
-                      matrix_item=$(jq -n \
-                        --arg name "$secret_name" \
-                        --arg suffix "$suffix" \
-                        --arg user_secret "$secret_name" \
-                        --arg password_secret "$password_secret" \
-                        '{
-                          name: $name,
-                          suffix: $suffix,
-                          user_secret: $user_secret,
-                          password_secret: $password_secret
-                        }')
-                      matrix_items+=("$matrix_item")
-                    fi
-                  done <<< "$staging_secrets"
-
-                  # Create final matrix
-                  if [ ${#matrix_items[@]} -eq 0 ]; then
-                    echo "No valid staging secrets found"
-                    exit 1
-                  fi
-
-                  # Join matrix items and create final JSON
-                  matrix_json=$(printf '%s\n' "${matrix_items[@]}" | jq -s '{"include": .}')
-
-                  # Output as a single line for GitHub Actions
-                  echo "matrix=$(echo "$matrix_json" | jq -c .)" >> $GITHUB_OUTPUT
-                  echo "Generated matrix:"
-                  echo "$matrix_json" | jq '.'
-
     Deploy:
         name: FTP-Deploy-Action
         runs-on: ubuntu-latest
-        needs: [Linting, generate-matrix]
+        needs: [Linting]
+        if: ${{ vars.STAGING_SITES != '' }}
         strategy:
-            matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+            matrix:
+                # Site names are defined in repository variable STAGING_SITES
+                # Example: STAGING_SITES = ["SITE_1","SITE_2","SITE_3"]
+                site_name: ${{ fromJSON(vars.STAGING_SITES) }}
             fail-fast: false
 
         steps:
@@ -112,7 +34,7 @@ jobs:
                   fetch-depth: 2
 
             - name: Use Node.js 18
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: '18'
 
@@ -130,10 +52,10 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --no-dev --optimize-autoloader
 
-            - name: FTP-Deploy-Action to staging${{ matrix.suffix }}
+            - name: FTP-Deploy-Action to Staging Site ${{ matrix.site_name }}
               uses: Automattic/FTP-Deploy-Action@3.1.2
               with:
                   ftp-server: sftp://sftp.wp.com/htdocs/wp-content/plugins/custom-plugin/
-                  ftp-username: ${{ secrets[matrix.user_secret] }}
-                  ftp-password: ${{ secrets[matrix.password_secret] }}
+                  ftp-username: ${{ secrets[format('STAGING_SFTP_USER_{0}', matrix.site_name)] }}
+                  ftp-password: ${{ secrets[format('STAGING_SFTP_PASSWORD_{0}', matrix.site_name)] }}
                   git-ftp-args: --insecure


### PR DESCRIPTION
This PR simplifies the GitHub Actions deployment workflows by replacing dynamic matrix generation with a cleaner approach using repository variables for storing the site names as a JSON array.

Changes:
- Remove the `generate-matrix` job that dynamically fetched secrets via GitHub API.
- Added conditional deployment, checking repository variables (`PROD_SITES` and `STAGING_SITES`).
- Updated `actions/setup-node` version to `v4`.
- New secret naming convention to use: `{ENV}_SFTP_USER_{SITE_NAME}` and `{ENV}_SFTP_PASSWORD_{SITE_NAME}`.

The workflow now expects a repo variable with an array-like structure:
```
["SITE_A","SITE_B"..."SITE_X"]
```

The site names could be any string as long as they match the corresponding secret suffixes and conform to GH variable names restrictions (only alphanumeric values and underscores are accepted).

Repo variable:  
`STAGING_SITES = ["MYSITE1","ANOTHER_SITE"]`

| Site Name    | Secret Variables (expected)                               |
|--------------|------------------------------------------------------------|
| `MYSITE1`    | `STAGING_SFTP_USER_MYSITE1`<br>`STAGING_SFTP_PASSWORD_MYSITE1` |
| `ANOTHER_SITE`| `STAGING_SFTP_USER_ANOTHER_SITE`<br>`STAGING_SFTP_PASSWORD_ANOTHER_SITE` |

