### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -48,7 +48,7 @@ jobs:
                   npm run build --if-present
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '7.4'
                   tools: composer:v2

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -48,7 +48,7 @@ jobs:
                   npm run build --if-present
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
               with:
                   php-version: '7.4'
                   tools: composer:v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - name: Install dependencies
-              uses: php-actions/composer@v6
+              uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6.1.2
             - name: Lint PHP files
               run: composer run lint
 


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 3
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# php-actions/composer # v6.1.2 -> 8a65f0d3c6a1d17ca4800491a40b5756a4c164f3
gh api repos/php-actions/composer/commits/v6.1.2 --jq '.sha'
# expected: 8a65f0d3c6a1d17ca4800491a40b5756a4c164f3

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
